### PR TITLE
Results-view (fix)

### DIFF
--- a/projects/components/results-view/bootstrap/results-view-selector/results-view-selector.ts
+++ b/projects/components/results-view/bootstrap/results-view-selector/results-view-selector.ts
@@ -63,11 +63,13 @@ export class BsResultsViewSelector implements OnChanges, OnDestroy {
     private buildViewAction() {
         if (this.resultsViewService.views.length <= 1) {
             this.viewAction = undefined;
+            this.items = [];
             return;
         }
         const includedViews = this.getIncludedViews();
         if (includedViews.length <= 1) {
             this.viewAction = undefined;
+            this.items = [];
             return;
         }
         if (this.useDropdownMenu) {


### PR DESCRIPTION
There is a bug showing when switching from a multi-view tab to a tab with only one view available. At that time, the tab with only one view available will show the previous tab views. 
This is because the "items" parameters is not updated when the number of views is only one and the "viewAction" parameter is undefined.
This fixes that by setting the "items" parameter as an empty array for these conditions.