### PR TITLE
Components / Preview (fix): fix similar-docs sending the wrong record on click

### DIFF
--- a/projects/components/preview/bootstrap/similar-docs/similar-docs.html
+++ b/projects/components/preview/bootstrap/similar-docs/similar-docs.html
@@ -1,6 +1,6 @@
 <ul class="list-group">
     <li class="list-group-item d-flex justify-content-between align-items-center" *ngFor="let doc of docs">
-        <sq-result-title [record]="doc.record" [titleLinkBehavior]="titleLinkBehavior" (titleClicked)="openDocument($event, record)"></sq-result-title>
+        <sq-result-title [record]="doc.record" [titleLinkBehavior]="titleLinkBehavior" (titleClicked)="openDocument($event, doc.record)"></sq-result-title>
         <span class="badge badge-pill" [ngClass]="doc.near_similarity? 'badge-primary' : 'badge-warning'">{{doc.pct}}</span>
     </li>
 </ul>


### PR DESCRIPTION
The component similar-docs in the Preview module was sending the wrong record on click on the document title. The record sent was the global record viewed in the preview, and not the current similar record that we are clicking on.