### PR TITLE
Components / Facets (fix): fix default values of list/tree facet

### DIFF
--- a/projects/components/facet/bootstrap/facet-list/facet-list.ts
+++ b/projects/components/facet/bootstrap/facet-list/facet-list.ts
@@ -122,6 +122,14 @@ export class BsFacetList extends AbstractFacet implements OnChanges {
         }, this.suggestDelay);
     }
 
+    ngOnInit() {
+        if (this.showCount === undefined) this.showCount = true;
+        if (this.searchable === undefined) this.searchable = true;
+        if (this.allowExclude === undefined) this.allowExclude = true;
+        if (this.allowOr === undefined) this.allowOr = true;
+        if (this.allowAnd === undefined) this.allowAnd = true;
+    }
+
     /**
      * Name of the facet, used to create and retrieve selections
      * through the facet service.

--- a/projects/components/facet/bootstrap/facet-list/facet-list.ts
+++ b/projects/components/facet/bootstrap/facet-list/facet-list.ts
@@ -122,14 +122,6 @@ export class BsFacetList extends AbstractFacet implements OnChanges {
         }, this.suggestDelay);
     }
 
-    ngOnInit() {
-        if (this.showCount === undefined) this.showCount = true;
-        if (this.searchable === undefined) this.searchable = true;
-        if (this.allowExclude === undefined) this.allowExclude = true;
-        if (this.allowOr === undefined) this.allowOr = true;
-        if (this.allowAnd === undefined) this.allowAnd = true;
-    }
-
     /**
      * Name of the facet, used to create and retrieve selections
      * through the facet service.
@@ -144,6 +136,12 @@ export class BsFacetList extends AbstractFacet implements OnChanges {
      * @param changes
      */
     ngOnChanges(changes: SimpleChanges) {
+        if (this.showCount === undefined) this.showCount = true;
+        if (this.searchable === undefined) this.searchable = true;
+        if (this.allowExclude === undefined) this.allowExclude = true;
+        if (this.allowOr === undefined) this.allowOr = true;
+        if (this.allowAnd === undefined) this.allowAnd = true;
+
         if (!!changes["results"]) {     // New data from the search service
             if(!this.count){
                 this.count = this.facetService.getAggregationCount(this.aggregation);

--- a/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
+++ b/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
@@ -82,12 +82,6 @@ export class BsFacetTree extends AbstractFacet implements OnChanges {
 
     }
 
-    ngOnInit() {
-        if (this.showCount === undefined) this.showCount = true;
-        if (this.allowExclude === undefined) this.allowExclude = true;
-        if (this.allowOr === undefined) this.allowOr = true;
-    }
-
     /**
      * Name of the facet, used to create and retrieve selections
      * through the facet service.
@@ -102,6 +96,10 @@ export class BsFacetTree extends AbstractFacet implements OnChanges {
      * @param changes
      */
     ngOnChanges(changes: SimpleChanges) {
+        if (this.showCount === undefined) this.showCount = true;
+        if (this.allowExclude === undefined) this.allowExclude = true;
+        if (this.allowOr === undefined) this.allowOr = true;
+
         if (!!changes["results"]) {     // New data from the search service
             this.filtered.clear();
             this.data = this.facetService.getTreeAggregation(this.getName(), this.aggregation, this.results, this.initNodes);

--- a/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
+++ b/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
@@ -82,6 +82,12 @@ export class BsFacetTree extends AbstractFacet implements OnChanges {
 
     }
 
+    ngOnInit() {
+        if (this.showCount === undefined) this.showCount = true;
+        if (this.allowExclude === undefined) this.allowExclude = true;
+        if (this.allowOr === undefined) this.allowOr = true;
+    }
+
     /**
      * Name of the facet, used to create and retrieve selections
      * through the facet service.


### PR DESCRIPTION
When the user setup an object "Facet" that will be used in a facet-multi component, if the properties such as "showCount", "searchable" etc... are not set by the user in the object, then they will be undefined. 
Instead of using the default value of the Input in the component facet-list/facet-tree, the values will be set to undefined.

This is due to the fact that the object first passes through the component facet-multi where the object is then sending "undefined" values to the facet-list/facet-tree component, instead of not sending any value at all. 
By adding an "ngOnInit" phase to the component, we can check for the input's value and set their default value if they are "undefined".  