### PR TITLE
Components / Baskets & Saved Queries: add search route input

### DIFF
--- a/projects/components/baskets/bootstrap/baskets-menu/baskets-menu.component.ts
+++ b/projects/components/baskets/bootstrap/baskets-menu/baskets-menu.component.ts
@@ -8,7 +8,7 @@ import { BasketsService } from '../../baskets.service';
   templateUrl: './baskets-menu.component.html'
 })
 export class BsBasketsMenuComponent implements OnInit {
-
+  @Input() searchRoute: string = "/search";
   @Input() icon: string = "fas fa-shopping-basket";
   @Input() autoAdjust: boolean = true;
   @Input() autoAdjustBreakpoint: string = 'xl';
@@ -71,7 +71,7 @@ export class BsBasketsMenuComponent implements OnInit {
                 text: basket.name,
                 title: basket.name,
                 data: basket,
-                action: _ => { this.basketsService.searchBasket(basket); }
+                action: _ => { this.basketsService.searchBasket(basket, this.searchRoute); }
             }));
         }
     }

--- a/projects/components/saved-queries/bootstrap/saved-queries-menu/saved-queries-menu.component.ts
+++ b/projects/components/saved-queries/bootstrap/saved-queries-menu/saved-queries-menu.component.ts
@@ -10,7 +10,7 @@ import { Subscription } from 'rxjs';
   templateUrl: './saved-queries-menu.component.html'
 })
 export class BsSavedQueriesMenuComponent implements OnInit, OnDestroy {
-
+  @Input() searchRoute: string = "/search";
   @Input() icon: string = "far fa-save";
   @Input() autoAdjust: boolean = true;
   @Input() autoAdjustBreakpoint: string = 'xl';
@@ -93,7 +93,7 @@ export class BsSavedQueriesMenuComponent implements OnInit, OnDestroy {
                 text: savedQuery.name,
                 title: savedQuery.name,
                 data: savedQuery,
-                action: (item: Action) => { this.savedQueriesService.searchSavedQuery(item.data); }
+                action: (item: Action) => { this.savedQueriesService.searchSavedQuery(item.data, this.searchRoute); }
             }));
         }
     }


### PR DESCRIPTION
The menus basket-menu and saved-query-menu component did not have the possibility to use a search route. This led to an impossibility to use these two menus in the homepage because they were using the route "/home", which will not lead to a search.