### PR TITLE
Components / Alerts (fix): fix the 'active' option not working on alerts

### DIFF
--- a/projects/components/alerts/bootstrap/edit-alert/edit-alert.ts
+++ b/projects/components/alerts/bootstrap/edit-alert/edit-alert.ts
@@ -60,7 +60,7 @@ export class BsEditAlert implements OnInit, OnDestroy {
             alertName: this.alertNameControl,
             alertFrequency: this.alertFrequencyControl,
             alertTimes: this.alertTimesControl,
-            alertActive: this.alertTimesControl,
+            alertActive: this.alertActiveControl,
             updateQuery: this.updateQueryControl
         });
         this.formChanges = Utils.subscribe(this.form.valueChanges,


### PR DESCRIPTION
The 'active' option was not working. When unchecking the box, the alert mail was sent anyway.
This is due to an error in the code where the `form` was built wrongly by using `alertActive: this.alertTimesControl` instead of `alertActive: this.alertActiveControl`.