### PR TITLE
Original document target window

### DIFF
--- a/projects/components/preview/bootstrap/facet-preview-2/facet-preview.component.html
+++ b/projects/components/preview/bootstrap/facet-preview-2/facet-preview.component.html
@@ -2,24 +2,24 @@
     <div *ngIf="loadingPreview" class="d-flex justify-content-center align-items-center h-100">
         <div class="spinner-grow" style="width: 3rem; height: 3rem;" role="status"></div>
     </div>
-    <sq-preview-document-iframe 
+    <sq-preview-document-iframe
                                 [sandbox]="sandbox"
-                                [downloadUrl]="downloadUrl" 
-                                [scalingFactor]="scalingFactor" 
+                                [downloadUrl]="downloadUrl"
+                                [scalingFactor]="scalingFactor"
                                 (onPreviewReady)="onPreviewReady($event)">
     </sq-preview-document-iframe>
 </div>
 
 <ng-template #headerTpl>
-    <sq-result-title class="flex-grow-1 flex-basis-0" [record]="record"></sq-result-title>
+    <sq-result-title class="flex-grow-1 flex-basis-0" [record]="record" [originalDocTarget]="originalDocTarget"></sq-result-title>
 </ng-template>
 
 <ng-template #subHeaderTpl>
     <sq-metadata *ngIf="metadata && metadata.length > 0"
-        [record]="record" 
+        [record]="record"
         [items]="metadata"
-        [showTitles]="true" 
-        [showIcons]="true" 
+        [showTitles]="true"
+        [showIcons]="true"
         [clickable]="false"
         [spacing]="'compact'">
     </sq-metadata>

--- a/projects/components/preview/bootstrap/facet-preview-2/facet-preview.component.ts
+++ b/projects/components/preview/bootstrap/facet-preview-2/facet-preview.component.ts
@@ -25,6 +25,7 @@ export class BsFacetPreviewComponent2 extends AbstractFacet implements OnChanges
   @Input() closable: boolean = true;
   @Input() customActions: Action[];
   @Input() filters: HighlightFilters;
+  @Input() originalDocTarget: string | undefined;
   @Output() recordClosed = new EventEmitter<void>();
   @Output() previewLoaded = new EventEmitter<PreviewDocument>();
   @HostBinding('style.height.px') _height: number = this.height;

--- a/projects/components/result/result-title/result-title.ts
+++ b/projects/components/result/result-title/result-title.ts
@@ -26,6 +26,7 @@ export class ResultTitle implements OnChanges {
     @Input() record: Record;
     @Input() titleLinkBehavior: "open" | "action" = "open";
     @Input() field: string = "";
+    @Input() originalDocTarget: string | undefined;
     @Output() titleClicked = new EventEmitter<boolean>();   // TODO: Custom options to get title & URL (replace pluginservice)
     public title: string;
     private titleField: string;
@@ -53,7 +54,7 @@ export class ResultTitle implements OnChanges {
     }
 
     public get target(): string {
-        return (this.hasLinkBehaviour && this.documentUrl) ? this.record.collection[0] || "_blank" : "_self";
+        return (this.hasLinkBehaviour && this.documentUrl) ? this.originalDocTarget || '_blank' : "_self";
     }
 
     private getTitle(): string {

--- a/projects/components/result/result-title/result-title.ts
+++ b/projects/components/result/result-title/result-title.ts
@@ -53,7 +53,7 @@ export class ResultTitle implements OnChanges {
     }
 
     public get target(): string {
-        return (this.hasLinkBehaviour && this.documentUrl) ? "_blank" : "_self";
+        return (this.hasLinkBehaviour && this.documentUrl) ? this.record.collection[0] || "_blank" : "_self";
     }
 
     private getTitle(): string {


### PR DESCRIPTION
Open original documents is the same target window, according to their original container (actually to the collection used to index the document).