### PR TITLE
Empty scalar rendering overridable

### DIFF
--- a/projects/components/metadata/messages/de.ts
+++ b/projects/components/metadata/messages/de.ts
@@ -59,7 +59,9 @@ export default {
             separator: " | ",
             treeSeparator: " ; ",
             treeNodeSeparator: "/",
-            listSeparator: ", "
+            listSeparator: ", ",
+            empty_boolean: 'false',
+            empty_number: '0'
         }
     }
 };

--- a/projects/components/metadata/messages/en.ts
+++ b/projects/components/metadata/messages/en.ts
@@ -59,7 +59,9 @@ export default {
             separator: " | ",
             treeSeparator: " ; ",
             treeNodeSeparator: "/",
-            listSeparator: ", "
+            listSeparator: ", ",
+            empty_boolean: 'false',
+            empty_number: '0'
         }
     },
 };

--- a/projects/components/metadata/messages/fr.ts
+++ b/projects/components/metadata/messages/fr.ts
@@ -59,7 +59,9 @@ export default {
             separator: " | ",
             treeSeparator: " ; ",
             treeNodeSeparator: "/",
-            listSeparator: ", "
+            listSeparator: ", ",
+            empty_boolean: 'false',
+            empty_number: '0'
         }
     },
 };

--- a/projects/components/metadata/metadata-item/metadata-item.ts
+++ b/projects/components/metadata/metadata-item/metadata-item.ts
@@ -38,10 +38,10 @@ export class MetadataItem implements OnChanges {
     ensureScalarValue(value: any): any {
         if (Utils.isEmpty(value) && this.column) {
             if (AppService.isBoolean(this.column)) {
-                value = false;
+                value = 'msg#metadata.item.empty_boolean';
             }
             else if (AppService.isNumber(this.column)) {
-                value = 0;
+                value = 'msg#metadata.item.empty_number';
             }
         }
         return value;


### PR DESCRIPTION
A short fix allowing dev to override the default empty scalar rendering.
Just add some messages in your locales. For instance, in `projects\vanilla-search\src\locales\messages\en.json`  add the following:
> `"metadata": { "item": { "empty_boolean": "N/A", "empty_number": "N/A" } },`

I've tried to remove `ensureScalarValue(value: any)` function but it has some non expected consequences. For instance:
if an undefined scalar is the last item, `<sq-metadata>` will append a `msg#metadata.item.separator` at the end ;  indeed, even if values haven't been pushed, `items.length` remains at its initial value. 