### PR TITLE
Components / Facet (fix/new): fix issue with tagcloud remove all filters + add possibility to choose which facets to display when using sq-facet-filters

### DIFF
--- a/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
+++ b/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
@@ -141,6 +141,7 @@ export class BsFacetFilters implements OnChanges {
     }
 
     get filteredFacets() {
+        if (!this.enableCustomization) return this.facets;
         let new_facets: FacetConfig[] = [];
 
         if (this.userFacets) {

--- a/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
+++ b/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnChanges} from "@angular/core";
+import {Component, Input, OnChanges, OnInit} from "@angular/core";
 import {Results} from "@sinequa/core/web-services";
 import {FacetService} from "../../facet.service";
 import {Action} from "@sinequa/components/action";
@@ -11,7 +11,7 @@ import {BsFacetTree} from '../facet-tree/facet-tree';
     templateUrl: "./facet-filters.html",
     styleUrls: ["./facet-filters.css"]
 })
-export class BsFacetFilters implements OnChanges {
+export class BsFacetFilters implements OnInit, OnChanges {
     @Input() results: Results;
     @Input() facets: FacetConfig[];
     @Input() enableCustomization = false;
@@ -40,6 +40,17 @@ export class BsFacetFilters implements OnChanges {
     ) {
         this.hidden = false;
         this.filters = [];
+    }
+
+    ngOnInit() {
+        if (!this.enableCustomization) return;
+
+        if (!this.facetService.defaultFacets) {
+            this.facetService.defaultFacets = [];
+            for (let facet of this.facets) this.facetService.defaultFacets.push({name: facet.name, position: 0, hidden: false, expanded: true, view: ""});
+        }
+
+        if (!this.facetService.allFacets) this.facetService.allFacets = this.facets;
     }
 
     ngOnChanges() {

--- a/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
+++ b/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
@@ -104,11 +104,11 @@ export class BsFacetFilters implements OnChanges {
 
         outFacets.push(new Action({
             name: `add_remove_all`,
-            text: this.userFacets.length < this.facets.length ? "Add all" : "Remove all",
+            text: this.userFacets.length < this.facets.length ? "msg#facet.filters.addAll" : "msg#facet.filters.removeAll",
             icon: this.hasFacetSelected ? 
                     (this.userFacets.length < this.facets.length ? "far fa-minus-square mr-1" : "far fa-check-square mr-1")
                     : "far fa-square mr-1",
-            title: this.userFacets.length < this.facets.length ? "Add all facets" : "Remove all facets",
+            title: this.userFacets.length < this.facets.length ? "msg#facet.filters.addAll" : "msg#facet.filters.removeAll",
             action: () => {
                 if (this.hasFacetSelected && this.userFacets.length === this.facets.length) this.facetService.removeAllFacet();
                 else this.facetService.addAllFacet();
@@ -118,11 +118,11 @@ export class BsFacetFilters implements OnChanges {
 
         for (let facet of this.facets) {
             outFacets.push(new Action({
-                name: `add_${facet.name}`,
+                name: `add_remove_${facet.name}`,
                 text: facet.title,
                 icon: facet.icon,
                 selected: !!this.userFacets?.find(userFacet => userFacet.name === facet.name),
-                title: `Add ${facet.title}`,
+                title: !!this.userFacets?.find(userFacet => userFacet.name === facet.name) ? "msg#facet.filters.add" : "msg#facet.filters.remove",
                 action: () => {
                     if (this.userFacets?.find(userFacet => userFacet.name === facet.name)) this.facetService.removeFacet({name: facet.name, position: 0, hidden: false, expanded: true, view: ""})
                     else this.facetService.addFacet({name: facet.name, position: 0, hidden: false, expanded: true, view: ""});
@@ -134,7 +134,7 @@ export class BsFacetFilters implements OnChanges {
         let add_action = new Action({
             name: "facets_config",
             icon: "fas fa-cog",
-            title: "Facets customization",
+            title: "msg#facet.filters.customizeFacets",
             children: outFacets
         });
         this.filters = [add_action, ...this.filters]; 

--- a/projects/components/facet/bootstrap/facet-tag-cloud/facet-tag-cloud.ts
+++ b/projects/components/facet/bootstrap/facet-tag-cloud/facet-tag-cloud.ts
@@ -7,6 +7,7 @@ import {
 } from "@sinequa/core/web-services";
 import { Action } from "@sinequa/components/action";
 import { FacetService } from "../../facet.service";
+import { Utils } from "@sinequa/core/base";
 
 export interface TagCloudItem {
     aggregation: Aggregation;
@@ -58,8 +59,10 @@ export class BsFacetTagCloud extends AbstractFacet implements OnChanges {
             icon: "far fa-minus-square",
             title: "msg#facet.clearSelects",
             action: () => {
-                for (const aggregation of this.aggregations) {
-                    this.facetService.clearFiltersSearch(this.getName(aggregation), true);
+                if (Utils.isArray(this.aggregations)) {
+                    for (const aggregation of this.aggregations) this.facetService.clearFiltersSearch(this.getName(aggregation), true);
+                } else { 
+                    this.facetService.clearFiltersSearch(this.getName(this.aggregations), true);
                 }
             },
         });

--- a/projects/components/facet/bootstrap/facet.module.ts
+++ b/projects/components/facet/bootstrap/facet.module.ts
@@ -58,7 +58,7 @@ import { BsFacetTagCloud } from './facet-tag-cloud/facet-tag-cloud';
     ],
 })
 export class BsFacetModule {
-    public static forRoot(allFacets: any[], defaultFacets: FacetState[]): ModuleWithProviders<BsFacetModule> {
+    public static forRoot(allFacets: any[]|undefined = undefined, defaultFacets: FacetState[]|undefined = undefined): ModuleWithProviders<BsFacetModule> {
         return {
             ngModule: BsFacetModule,
             providers: [

--- a/projects/components/facet/bootstrap/facet.module.ts
+++ b/projects/components/facet/bootstrap/facet.module.ts
@@ -58,7 +58,7 @@ import { BsFacetTagCloud } from './facet-tag-cloud/facet-tag-cloud';
     ],
 })
 export class BsFacetModule {
-    public static forRoot(allFacets: any[] = [], defaultFacets: FacetState[] = []): ModuleWithProviders<BsFacetModule> {
+    public static forRoot(allFacets: any[], defaultFacets: FacetState[]): ModuleWithProviders<BsFacetModule> {
         return {
             ngModule: BsFacetModule,
             providers: [

--- a/projects/components/facet/facet.service.ts
+++ b/projects/components/facet/facet.service.ts
@@ -62,9 +62,6 @@ export interface FacetChangeEvent {
     facet?: FacetState;
 }
 
-export const ALL_FACETS = new InjectionToken<any[]>('ALL_FACETS');
-export const DEFAULT_FACETS = new InjectionToken<FacetState[]>('DEFAULT_FACETS');
-
 @Injectable({
     providedIn: 'root',
 })
@@ -73,6 +70,9 @@ export class FacetService {
     protected readonly _events = new Subject<FacetChangeEvent>();
     protected readonly _changes = new Subject<FacetChangeEvent>();
 
+    private _allFacets: any[];
+    private _defaultFacets: FacetState[];
+
     constructor(
         protected userSettingsService: UserSettingsWebService,
         protected searchService: SearchService,
@@ -80,9 +80,7 @@ export class FacetService {
         protected appService: AppService,
         protected intlService: IntlService,
         protected formatService: FormatService,
-        protected exprBuilder: ExprBuilder,
-        @Optional() @Inject(ALL_FACETS) protected allFacets: any[],
-        @Optional() @Inject(DEFAULT_FACETS) protected defaultFacets: FacetState[]){
+        protected exprBuilder: ExprBuilder){
 
         // Listen to the user settings
         this.userSettingsService.events.subscribe(event => {
@@ -118,12 +116,20 @@ export class FacetService {
         return this.userSettingsService.userSettings["facets"];
     }
 
-    public setAllFacets(facets: FacetState[]) {
-        this.allFacets = facets;
+    public get allFacets() {
+        return this._allFacets;
     }
 
-    public setDefaultFacets(facets: FacetState[]) {
-        this.defaultFacets = facets;
+    public set allFacets(facets: any[]) {
+        this._allFacets = facets;
+    }
+
+    public get defaultFacets() {
+        return this._defaultFacets
+    }
+
+    public set defaultFacets(facets: FacetState[]) {
+        this._defaultFacets = facets;
     }
 
     /**

--- a/projects/components/facet/facet.service.ts
+++ b/projects/components/facet/facet.service.ts
@@ -37,7 +37,9 @@ export interface AddFilterOptions {
 export const enum FacetEventType {
     Loaded = "Facet_Loaded",
     Add = "Facet_Added",
+    AddAll = "Facets_Added",
     Remove = "Facet_Removed",
+    RemoveAll = "Facets_Removed",
 
     Patched = "Facet_Patched",
     ClearFilters = "Facet_ClearFilters",
@@ -116,6 +118,14 @@ export class FacetService {
         return this.userSettingsService.userSettings["facets"];
     }
 
+    public setAllFacets(facets: FacetState[]) {
+        this.allFacets = facets;
+    }
+
+    public setDefaultFacets(facets: FacetState[]) {
+        this.defaultFacets = facets;
+    }
+
     /**
      * @returns a facet with the given name or undefined if it does not exist
      * @param name
@@ -188,7 +198,7 @@ export class FacetService {
             this.facets.splice(i,1);
             this.events.next({type : FacetEventType.Remove, facet: facet});
             this.patchFacets([{
-                type: FacetEventType.Add,
+                type: FacetEventType.Remove,
                 detail: {
                     facet: facet.name
                 }
@@ -196,6 +206,22 @@ export class FacetService {
         }
     }
 
+    public addAllFacet() {
+        this.facets.splice(0,this.facets.length);
+        if(!!this.defaultFacets) this.facets.push(...this.defaultFacets);
+        this.events.next({type : FacetEventType.AddAll});
+        this.patchFacets([{
+            type: FacetEventType.AddAll
+        }]);
+    }
+
+    public removeAllFacet() {
+        this.facets.splice(0,this.facets.length);
+        this.events.next({type : FacetEventType.RemoveAll});
+        this.patchFacets([{
+            type: FacetEventType.RemoveAll
+        }]);
+    }
 
     /**
      * Updates facets in User settings.

--- a/projects/components/facet/facet.service.ts
+++ b/projects/components/facet/facet.service.ts
@@ -62,6 +62,9 @@ export interface FacetChangeEvent {
     facet?: FacetState;
 }
 
+export const ALL_FACETS = new InjectionToken<any[]>('ALL_FACETS');
+export const DEFAULT_FACETS = new InjectionToken<FacetState[]>('DEFAULT_FACETS');
+
 @Injectable({
     providedIn: 'root',
 })
@@ -70,9 +73,6 @@ export class FacetService {
     protected readonly _events = new Subject<FacetChangeEvent>();
     protected readonly _changes = new Subject<FacetChangeEvent>();
 
-    private _allFacets: any[];
-    private _defaultFacets: FacetState[];
-
     constructor(
         protected userSettingsService: UserSettingsWebService,
         protected searchService: SearchService,
@@ -80,7 +80,9 @@ export class FacetService {
         protected appService: AppService,
         protected intlService: IntlService,
         protected formatService: FormatService,
-        protected exprBuilder: ExprBuilder){
+        protected exprBuilder: ExprBuilder,
+        @Optional() @Inject(ALL_FACETS) public allFacets: any[],
+        @Optional() @Inject(DEFAULT_FACETS) public defaultFacets: FacetState[]){
 
         // Listen to the user settings
         this.userSettingsService.events.subscribe(event => {
@@ -114,22 +116,6 @@ export class FacetService {
             }
         }
         return this.userSettingsService.userSettings["facets"];
-    }
-
-    public get allFacets() {
-        return this._allFacets;
-    }
-
-    public set allFacets(facets: any[]) {
-        this._allFacets = facets;
-    }
-
-    public get defaultFacets() {
-        return this._defaultFacets
-    }
-
-    public set defaultFacets(facets: FacetState[]) {
-        this._defaultFacets = facets;
     }
 
     /**

--- a/projects/components/facet/messages/de.ts
+++ b/projects/components/facet/messages/de.ts
@@ -104,14 +104,18 @@ export default {
 
         "filters":{
             "add":"Filter hinzufügen",
+            "addAll": "Alle Facetten hinzufügen",
             "remove":"Filter entfernen",
+            "removeAll": "Alle Facetten entfernen",
             "clear":"Filter löschen",
             "moreFilters":"",
             "showFilters":"Filter einblenden",
             "hideFilters":"Filter ausblenden",
 
             "back": "Zurück zu den Filtern",
-            "selectedFilters": "Dieser Filter ist in der aktuellen Suchanfrage aktiv"
+            "selectedFilters": "Dieser Filter ist in der aktuellen Suchanfrage aktiv",
+
+            "customizeFacets": "Facetten zum Anzeigen oder Ausblenden auswählen"
         },
 
         "selectedValue": "Dieser Wert ist in der aktuellen Anfrage ausgewählt.",

--- a/projects/components/facet/messages/en.ts
+++ b/projects/components/facet/messages/en.ts
@@ -106,14 +106,18 @@ export default {
 
         "filters":{
             "add":"Add facet",
+            "addAll": "Add all facets",
             "remove":"Remove facet",
+            "removeAll": "Remove all facets",
             "clear":"Clear filter",
             "moreFilters":"",
             "showFilters":"Show filters",
             "hideFilters":"Hide filters",
 
             "back": "Back to filters",
-            "selectedFilters": "This filter is active in the current query"
+            "selectedFilters": "This filter is active in the current query",
+
+            "customizeFacets": "Select facets to display or hide"
         },
 
         "selectedValue": "This value is selected in the current query",

--- a/projects/components/facet/messages/fr.ts
+++ b/projects/components/facet/messages/fr.ts
@@ -106,14 +106,18 @@ export default {
 
         "filters":{
             "add":"Ajouter la facette",
+            "addAll": "Ajouter toutes les facettes",
             "remove":"Retirer la facette",
+            "removeAll": "Retirer toutes les facettes",
             "clear":"Réinitialiser",
             "moreFilters":"",
             "showFilters":"Montrer les filtres",
             "hideFilters":"Cacher les filtres",
 
             "back": "Retour aux filtres",
-            "selectedFilters": "Ce filtre est utilisé dans la recherche actuelle"
+            "selectedFilters": "Ce filtre est utilisé dans la recherche actuelle",
+
+            "customizeFacets": "Sélectionnez les facettes à montrer ou cacher"
         },
 
         "selectedValue": "Cette valeur est sélectionnée dans la recherche actuelle",


### PR DESCRIPTION
There are two modifications associated with this pull request:

1. Fix a tagcloud bug where the clear all filters wouldn't work when the Input `aggregations` was a string. There is a possibility to set a string for this input, when the tagcloud is about only one column. Since there is this possibility, I adapted the code to clear the filters to check if the `aggregations` was an array or not.

2. In the component BsFacetFilters, I implemented the option for a user to add/remove a facet from the list of the facets he/she wants to display.