### PR TITLE
fix i18n display in preview-entity-facet

### DIFF
--- a/projects/components/preview/bootstrap/preview-entity-facet/preview-entity-facet.component.html
+++ b/projects/components/preview/bootstrap/preview-entity-facet/preview-entity-facet.component.html
@@ -3,7 +3,7 @@
         <span class="text-muted px-1 cursor-pointer" (click)="toggleEntity(value)">
             <i class="far" [ngClass]="{'fa-check-square': !entityHidden(value), 'fa-square': entityHidden(value)}"></i>
         </span>
-        <span class="mr-auto mx-1">{{ value.displayValue | sqValue }}</span>
+        <span class="mr-auto mx-1">{{ value.displayValue | sqValue:column }}</span>
         <span class="text-muted small mx-1">{{ entityCount(value) }}</span>
         <span *ngIf="previewDocument" class="text-muted px-1 cursor-pointer" (click)="prevEntity(value)" title="{{ 'msg#preview.previousHighlightButtonAltText' | sqMessage }}"><i class="fas fa-chevron-left"></i></span>
         <span *ngIf="previewDocument" class="text-muted px-1 cursor-pointer" (click)="nextEntity(value)" title="{{ 'msg#preview.nextHighlightButtonAltText' | sqMessage }}"><i class="fas fa-chevron-right"></i></span>

--- a/projects/components/preview/bootstrap/preview-entity-facet/preview-entity-facet.component.html
+++ b/projects/components/preview/bootstrap/preview-entity-facet/preview-entity-facet.component.html
@@ -3,7 +3,7 @@
         <span class="text-muted px-1 cursor-pointer" (click)="toggleEntity(value)">
             <i class="far" [ngClass]="{'fa-check-square': !entityHidden(value), 'fa-square': entityHidden(value)}"></i>
         </span>
-        <span class="mr-auto mx-1">{{ value.displayValue }}</span>
+        <span class="mr-auto mx-1">{{ value.displayValue | sqValue }}</span>
         <span class="text-muted small mx-1">{{ entityCount(value) }}</span>
         <span *ngIf="previewDocument" class="text-muted px-1 cursor-pointer" (click)="prevEntity(value)" title="{{ 'msg#preview.previousHighlightButtonAltText' | sqMessage }}"><i class="fas fa-chevron-left"></i></span>
         <span *ngIf="previewDocument" class="text-muted px-1 cursor-pointer" (click)="nextEntity(value)" title="{{ 'msg#preview.nextHighlightButtonAltText' | sqMessage }}"><i class="fas fa-chevron-right"></i></span>

--- a/projects/components/preview/bootstrap/preview-entity-facet/preview-entity-facet.component.ts
+++ b/projects/components/preview/bootstrap/preview-entity-facet/preview-entity-facet.component.ts
@@ -1,8 +1,9 @@
 import { Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges } from '@angular/core';
-import { HighlightValue, PreviewData } from '@sinequa/core/web-services';
+import { HighlightValue, PreviewData, CCColumn } from '@sinequa/core/web-services';
 import { PreviewDocument } from '../../preview-document';
 import { AbstractFacet } from '@sinequa/components/facet';
 import { Action } from '@sinequa/components/action';
+import { AppService } from '@sinequa/core/app-utils';
 
 @Component({
   selector: 'sq-preview-entity-facet',
@@ -21,12 +22,15 @@ export class BsPreviewEntityFacetComponent extends AbstractFacet implements OnIn
   sortFreq: boolean = true;
   hidden = new Map<string, boolean>();
   nav = new Map<string, number>();
+  column: CCColumn | undefined;
 
   checkAction: Action;
   sortFreqAction: Action;
   sortAlphaAction: Action;
 
-  constructor() {
+  constructor(
+    private appService:AppService
+  ) {
     super();
 
     this.checkAction = new Action({
@@ -90,6 +94,7 @@ export class BsPreviewEntityFacetComponent extends AbstractFacet implements OnIn
       this.unselectAll();
       this.checkAction.update();
     }
+    this.column = this.appService.getColumn(this.entity);
   }
 
   /**


### PR DESCRIPTION
In entity facet (preview), i18n entity labels (like "Xxx[fr]Yyy") are displayed as it and are not "i18n decoded" (it should only display "Xxx" or "Yyy" based on user local).