### PR TITLE
Components / Facets (change): make the filtered items public

### DIFF
--- a/projects/components/facet/bootstrap/facet-tag-cloud/facet-tag-cloud.ts
+++ b/projects/components/facet/bootstrap/facet-tag-cloud/facet-tag-cloud.ts
@@ -43,7 +43,7 @@ export class BsFacetTagCloud extends AbstractFacet implements OnChanges {
 
     aggregationsData: Aggregation[] = [];
     tagCloudData: TagCloudItem[] = [];
-    private filtered: AggregationItem[] = [];
+    filtered: AggregationItem[] = [];
 
     // Actions enabled within the facet
     private readonly clearFilters: Action;

--- a/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
+++ b/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
@@ -33,7 +33,7 @@ export class BsFacetTree extends AbstractFacet implements OnChanges, OnDestroy {
     private readonly subscriptions: Subscription[] = [];
 
     // Sets to keep track of selected/excluded/filtered items
-    private readonly filtered = new Set<AggregationItem>();
+    readonly filtered = new Set<AggregationItem>();
     
     readonly selected = new Map<string,TreeAggregationNode>();
 


### PR DESCRIPTION
Small change to make filtered items public. This allows components extending these facets to also access the filtered items.

EDIT: I see that my pull-request did not pass the automatic check, but I believe this has to be with the latest changes brought by the 11.7, and not by the changes I did. My changes are very small and only remove "private" from two parameters.