### PR TITLE
Components / Action (change): allow objects in dropdown-menu to get custom classes

### DIFF
--- a/projects/components/action/bootstrap/action-item-content/action-item-content.html
+++ b/projects/components/action/bootstrap/action-item-content/action-item-content.html
@@ -2,7 +2,7 @@
 
 <ng-template #in_dropdown_menu>
     <ng-container *ngIf="!!item.component" (click)="componentClick($event)"[sqLoadComponent]="{component: item.component, inputs: item.componentInputs }"></ng-container>
-    <div *ngIf="!!!item.component" class="d-flex flex-row sq-action-item-content-container">
+    <div *ngIf="!!!item.component" class="d-flex flex-row sq-action-item-content-container" [ngClass]="item.styles || ''">
         <div *ngIf="item.showSelected"><span class="fas fa-check {{item.selected ? '' : 'invisible'}}" aria-hidden="true"></span></div>
         <div *ngIf="!!item.icon"><span class="{{item.icon}}" aria-hidden="true"></span></div>
         <div>{{text | sqMessage:item.messageParams}}</div>


### PR DESCRIPTION
This change gives the possibility to add customized classes to some dropdown items which will allow for customization of specific dropdown items.
Ex: make the style of "Manage baskets"/"Create baskets" different from the style of the baskets items.