### PR TITLE
Components / Facet Filters + Core / AppService

### DIFF
--- a/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
+++ b/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
@@ -65,7 +65,7 @@ export class BsFacetFilters implements OnInit, OnChanges {
     /**
      * Build filters bar actions
      */
-    private buildFilters() {
+    protected buildFilters() {
 
         // For each facet
         this.filters = this.filteredFacets.map((facet: FacetConfig) => {
@@ -100,7 +100,7 @@ export class BsFacetFilters implements OnInit, OnChanges {
      *
      * @returns true if filters are sets otherwise false
      */
-    private hasFiltered(facetName): boolean {
+    protected hasFiltered(facetName): boolean {
         return this.facetService.hasFiltered(facetName);
     }
 
@@ -110,11 +110,11 @@ export class BsFacetFilters implements OnInit, OnChanges {
      *
      * @returns true if facet contains at least one item otherwise false
      */
-    private hasData(facet: FacetConfig): boolean {
+     protected hasData(facet: FacetConfig): boolean {
         return this.facetService.hasData(facet.aggregation, this.results);
     }
 
-    private addFacetMenu() {
+    protected addFacetMenu() {
         let outFacets: Action[] = [];
 
         outFacets.push(new Action({

--- a/projects/core/app-utils/app.service.ts
+++ b/projects/core/app-utils/app.service.ts
@@ -633,16 +633,16 @@ export class AppService implements OnDestroy {
     /**
      * Get the {@link CCColumn} with the passed name. Aliases are resolved
      */
-    getColumn(name: string | null | undefined): CCColumn | undefined {
+    getColumn(name: string | null | undefined, ccquery = this.ccquery): CCColumn | undefined {
         if (!name) {
             return undefined;
         }
-        if (!this.ccquery) {
+        if (!ccquery) {
             return undefined;
         }
         // First, CCQuery specific aliases
         let column: CCColumn;
-        let columnAliases = this.columnsByQuery[Utils.toLowerCase(this.ccquery.name)];
+        let columnAliases = this.columnsByQuery[Utils.toLowerCase(ccquery.name)];
         if (columnAliases) {
             column = columnAliases[Utils.toLowerCase(name)];
             if (column) {
@@ -650,7 +650,7 @@ export class AppService implements OnDestroy {
             }
         }
         // Second, aliases by index
-        const indexes = Utils.split(this.ccquery.searchIndexes, [","]);
+        const indexes = Utils.split(ccquery.searchIndexes, [","]);
         const firstIndex = indexes.length === 0 ? undefined : this.getIndex(indexes[0]);
         if (indexes.length === 0 || (!!firstIndex && this.indexIsNormal(firstIndex))) {
             columnAliases = this.columnsByIndex._;


### PR DESCRIPTION
The facet filters change allows for component extending it to modify the functions in case there are some details that they want to change (for example, not use the BsFacetList and BsFacetTree components, but other ones).

The app service function getColumn now has a new parameter ccquery. This change allows to get the cccolumn of any queries. By default, if the ccquery parameter is not passed, we will use the ccquery variable of the app service. 