### PR TITLE
Components / Facet (change): Make the default facet-card actions public

### DIFF
--- a/projects/components/facet/bootstrap/facet-card/facet-card.ts
+++ b/projects/components/facet/bootstrap/facet-card/facet-card.ts
@@ -111,9 +111,9 @@ export class BsFacetCard implements OnInit, OnDestroy, AfterContentInit {
         return !!this.facetComponent && !!this.facetComponent.isHidden && this.facetComponent.isHidden();
     }
 
-    private readonly collapseAction;
-    private readonly expandAction;
-    private readonly settingsAction;
+    public readonly collapseAction;
+    public readonly expandAction;
+    public readonly settingsAction;
 
     private actionChangedSubscription: Subscription;
 


### PR DESCRIPTION
This change is made to allow the use of the facet-card default actions in expanding components or facet-card instances.