### PR TITLE
Analytics / Heatmap (change): add a loading flag to show the user when the heatmap's data is loading

### DIFF
--- a/projects/analytics/heatmap/bootstrap/facet-heatmap.component.html
+++ b/projects/analytics/heatmap/bootstrap/facet-heatmap.component.html
@@ -1,4 +1,4 @@
-<sq-heatmap *ngIf="data && ready"
+<sq-heatmap *ngIf="data && ready && !loading"
     [data]="data"
     [height]="heightPref"
     [width]="widthPref"
@@ -17,8 +17,12 @@
 >
 </sq-heatmap>
 
-<div class="text-center py-5 px-3" *ngIf="!data">
+<div class="text-center py-5 px-3" *ngIf="!data && !loading">
     <i>{{'msg#heatmap.nodata' | sqMessage}}</i>
+</div>
+
+<div class="text-center py-5 px-3" *ngIf="loading">
+    <i>{{'msg#heatmap.loading' | sqMessage}}</i>
 </div>
 
 <ng-template #settingsTpl>

--- a/projects/analytics/heatmap/bootstrap/facet-heatmap.component.ts
+++ b/projects/analytics/heatmap/bootstrap/facet-heatmap.component.ts
@@ -64,6 +64,9 @@ export class BsFacetHeatmapComponent extends AbstractFacet implements OnChanges,
     // the heatmap component without displaying causes strange bugs...
     ready = false;
 
+    // A flag to check if the data is currently loading or not
+    loading = false;
+
     constructor(
         public appService: AppService,
         public searchService: SearchService,
@@ -147,6 +150,7 @@ export class BsFacetHeatmapComponent extends AbstractFacet implements OnChanges,
      * Updates the heatmap data
      */
     updateData() {
+        this.loading = true;
         if(this.results) {
             this.aggregationData = this.facetService.getAggregation(this.aggregation, this.results);
             if(!this.aggregationData){
@@ -158,6 +162,7 @@ export class BsFacetHeatmapComponent extends AbstractFacet implements OnChanges,
         }
         else {
             this.data = undefined;
+            this.loading = false;
         }
     }
 
@@ -254,6 +259,7 @@ export class BsFacetHeatmapComponent extends AbstractFacet implements OnChanges,
      * Transform an aggregation into a list of HeatmapItem objects
      */
     processAggregation(): HeatmapItem[] | undefined {
+        this.loading = false;
         if (!this.aggregationData || !this.aggregationData.items) {
             return undefined;
         }

--- a/projects/analytics/heatmap/messages/de.ts
+++ b/projects/analytics/heatmap/messages/de.ts
@@ -2,6 +2,7 @@ export default {
     "heatmap": {
         "name": "Heatmap-Diagramm",
         "nodata": "Keine Daten zum Anzeigen",
+        "loading": "Laden",
         "maxX": "Maximale Anzahl von Elementen auf der X-Achse",
         "maxY": "Maximale Anzahl von Elementen auf der Y-Achse",
         "rescale": "Achsen neu skalieren",

--- a/projects/analytics/heatmap/messages/en.ts
+++ b/projects/analytics/heatmap/messages/en.ts
@@ -2,6 +2,7 @@ export default {
     "heatmap": {
         "name": "Heatmap",
         "nodata": "No data to display",
+        "loading": "Loading",
         "maxX": "Max items on X axis",
         "maxY": "Max items on Y axis",
         "rescale": "Re-scale axes",

--- a/projects/analytics/heatmap/messages/fr.ts
+++ b/projects/analytics/heatmap/messages/fr.ts
@@ -2,6 +2,7 @@ export default {
     "heatmap": {
         "name": "Carte de chaleur",
         "nodata": "Pas de données à afficher",
+        "loading": "Chargement",
         "maxX": "Nombre maximum d'éléments sur l'axe X",
         "maxY": "Nombre maximum d'éléments sur l'axe Y",
         "rescale": "Redimensionner les axes",


### PR DESCRIPTION
It can be a bit difficult for the user to understand that data is loading if the display stays the same, so this change adds a loading state to the heatmap display.
The loading state will be set to true when the data is being fetched from the server. When the data comes back, or when the data is empty, the loading state is switched back to false. 