### PR TITLE
BSFacetTree allowAnd Option

### DIFF
--- a/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
+++ b/projects/components/facet/bootstrap/facet-filters/facet-filters.ts
@@ -73,7 +73,19 @@ export class BsFacetFilters implements OnInit, OnChanges {
             const children = [
                 new Action({
                     component: (facet.type === 'list') ? BsFacetList : BsFacetTree,
-                    componentInputs: {results: this.results, name: facet.name, aggregation: facet.aggregation, searchable: facet.searchable, displayActions: true}
+                    componentInputs: {
+                        results: this.results, 
+                        name: facet.name, 
+                        aggregation: facet.aggregation, 
+                        searchable: facet.searchable, 
+                        displayActions: true,
+                        showCount: facet.showCount,
+                        allowExclude: facet.allowExclude,
+                        allowOr: facet.allowOr,
+                        allowAnd: facet.allowAnd,
+                        displayEmptyDistributionIntervals:
+                          facet.displayEmptyDistributionIntervals
+                    }
                 })
             ];
 

--- a/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
+++ b/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
@@ -21,10 +21,12 @@ export class BsFacetTree extends AbstractFacet implements OnChanges, OnDestroy {
     @Input() showCount: boolean = true; // Show the number of occurrences
     @Input() allowExclude: boolean = true; // Allow to exclude selected items
     @Input() allowOr: boolean = true; // Allow to search various items in OR mode
+    @Input() allowAnd: boolean = true; // Allow to search various items in OR mode
     @Input() searchable: boolean = true; // Allow to search for items in the facet
     @Input() expandedLevel: number = 2;
     @Input() forceMaxHeight: boolean = true; // Allow to display a scrollbar automatically on long list items
     @Input() displayActions = false;
+    @Input() replaceCurrent = false; // if true, the previous "select" is removed first
 
     // Aggregation from the Results object
     data: TreeAggregation | undefined;
@@ -51,6 +53,7 @@ export class BsFacetTree extends AbstractFacet implements OnChanges, OnDestroy {
     // Actions (displayed in facet menu)
     // All actions are built in the constructor
     private readonly filterItemsOr: Action;
+    private readonly filterItemsAnd: Action;
     private readonly excludeItems: Action;
     private readonly clearFilters: Action;
     public readonly searchItems: Action;
@@ -93,6 +96,17 @@ export class BsFacetTree extends AbstractFacet implements OnChanges, OnDestroy {
                     }
                 }
             });
+
+            // Keep documents with ALL the selected items
+            this.filterItemsAnd = new Action({
+                icon: "fas fa-bullseye",
+                title: "msg#facet.filterItemsAnd",
+                action: () => {
+                    if (this.data) {
+                        this.facetService.addFilterSearch(this.getName(), this.data as Aggregation, this.getSelectedItems(), {and: true, replaceCurrent: this.replaceCurrent});
+                }
+            }
+        });
 
             // Exclude document with selected items
             this.excludeItems = new Action({
@@ -147,6 +161,7 @@ export class BsFacetTree extends AbstractFacet implements OnChanges, OnDestroy {
         if (this.searchable === undefined) this.searchable = true;
         if (this.allowExclude === undefined) this.allowExclude = true;
         if (this.allowOr === undefined) this.allowOr = true;
+        if (this.allowAnd === undefined) this.allowAnd = false;
 
         if (changes.results || changes.aggregation) {     // New data from the search service
             this.filtered.clear();
@@ -184,6 +199,9 @@ export class BsFacetTree extends AbstractFacet implements OnChanges, OnDestroy {
         if(this.selected.size > 0) {
             if(this.allowOr){
                 actions.push(this.filterItemsOr);
+            }
+            if(this.allowAnd && (this.filtered.size + this.selected.size) > 1){
+                actions.push(this.filterItemsAnd);
             }
             if(this.allowExclude){
                 actions.push(this.excludeItems);

--- a/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
+++ b/projects/components/facet/bootstrap/facet-tree/facet-tree.ts
@@ -21,7 +21,7 @@ export class BsFacetTree extends AbstractFacet implements OnChanges, OnDestroy {
     @Input() showCount: boolean = true; // Show the number of occurrences
     @Input() allowExclude: boolean = true; // Allow to exclude selected items
     @Input() allowOr: boolean = true; // Allow to search various items in OR mode
-    @Input() allowAnd: boolean = true; // Allow to search various items in OR mode
+    @Input() allowAnd: boolean = false; // Allow to search various items in OR mode
     @Input() searchable: boolean = true; // Allow to search for items in the facet
     @Input() expandedLevel: number = 2;
     @Input() forceMaxHeight: boolean = true; // Allow to display a scrollbar automatically on long list items


### PR DESCRIPTION
Particularly convenient for Classifiers:

allow user to select several item and filter them with a AND
allow user to filter again with another item