### PR TITLE
Components / Facet (fix): set value of aggregation item to value when present instead of display

### DIFF
--- a/projects/components/facet/facet.service.ts
+++ b/projects/components/facet/facet.service.ts
@@ -927,7 +927,7 @@ export class FacetService {
                     value = Utils.isTrue(item.value);
                 }
                 if (item.column?.eType === EngineType.csv) {
-                    value = item.display || item.value || "";
+                    value = item.value || item.display || "";
                     const path = item.value?.slice(0, -1);
                     return ({count: 0, value, display: item.display, $column: item.column, $path: path, $excluded: (item?.not || item?.parent?.not)} as TreeAggregationNode);
                 }


### PR DESCRIPTION
When transforming an Expr to an AggregationItem, in the case of a csv type item, now prioritizes the item.value instead of the item.display for the AggregationItem value. 
This is important in the case of entities where the normalized value is different from the displayed value.