### PR TITLE
Fix the escaping of html elements passed to formatjs

### DIFF
--- a/projects/core/intl/intl.service.ts
+++ b/projects/core/intl/intl.service.ts
@@ -629,7 +629,7 @@ export class IntlService implements OnDestroy {
             try {
                 // escaping XML/HTML tags according to intl-messageformat documentation
                 //https://formatjs.io/docs/intl-messageformat/
-                const formatter = formatters.getMessageFormat(message.replace(/(<\/?[^>]+>)/gi, "'$1'"), this.intlLocale, this.formats, {formatters: formatters as any});
+                const formatter = formatters.getMessageFormat(message.replace(/((<\/?[^>]+>)+)/gi, "'$1'"), this.intlLocale, this.formats, {formatters: formatters as any});
                 const formattedMessage = formatter.format(values);
                 return formattedMessage;
             }


### PR DESCRIPTION
This PR resolves this issue: https://github.com/sinequa/sba-angular/issues/108

Currently, when formatting the message `<span>foo</span><span>bar</span>` we escape it with `'<span>'foo'</span>''<span>'bar'</span>'` (note the double `'` in the middle). FormatJS leaves a single quote in the result, which is not the desired behavior.

A slight modification of the regular expression resolves the problem by escaping complete sequence of tags: `'<span>'foo'</span><span>'bar'</span>'`.