### PR TITLE
set timeout for JsonMethodPlugin post requests

### DIFF
--- a/projects/core/web-services/json-method-plugin.web.service.ts
+++ b/projects/core/web-services/json-method-plugin.web.service.ts
@@ -23,7 +23,11 @@ export class JsonMethodPluginService extends HttpService{
     if (!Utils.isObject(query)) {
       return throwError({error: "invalid query object"});
     }
-    const observable = this.httpClient.post(this.makeUrl(method), query, options);
+    const timeoutInMin = options && 'timeoutInMin' in options ? options.timeoutInMin : 1;
+    if (options && 'timeoutInMin' in options) delete options.timeoutInMin;
+    const observable = this.httpClient.post(this.makeUrl(method), query, options).pipe(
+      timeout(timeoutInMin * 60 * 1000),
+    );
 
     Utils.subscribe(observable,
       (response) => {


### PR DESCRIPTION
By default, angular httpClient has a timeout of 1min. But since OpenAI ChatGPT completion requests may take several minutes to respond, I've added in options parameter a way to specify a timeout in minutes. I'm sure it's not the best way to do it...