### PR TITLE
label for suggestion type

### DIFF
--- a/projects/vanilla-search/src/app/search-form/autocomplete.component.ts
+++ b/projects/vanilla-search/src/app/search-form/autocomplete.component.ts
@@ -179,7 +179,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
       this.recentQueriesService.recentqueries,
       (query) => query.query.text || "",
       undefined,
-      "msg#searchForm.recentQuery");
+      "msg#autocomplete.recentQuery");
   }
 
   /**
@@ -193,7 +193,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
       this.recentDocumentsService.recentdocuments,
       doc => doc.title,
       doc => ([] as string[]).concat(doc.url1, doc.treepath, doc.authors),
-      "msg#searchForm.recentDocument");
+      "msg#autocomplete.recentDocument");
   }
 
   /**
@@ -207,7 +207,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
       this.savedQueriesService.savedqueries,
       (query) => query.name,
       (query) => [query.description || "", query.query.text || ""],
-      "msg#editSavedQuery.title");
+      "msg#autocomplete.savedQuery");
   }
 
   /**
@@ -221,7 +221,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
       this.basketsService.baskets,
       (bsk) => bsk.name,
       (bsk) => [bsk.description || ""],
-      "msg#editBasket.title");
+      "msg#autocomplete.basket");
   }
 
   /**

--- a/projects/vanilla-search/src/app/search-form/autocomplete.component.ts
+++ b/projects/vanilla-search/src/app/search-form/autocomplete.component.ts
@@ -8,6 +8,7 @@ import { AppService } from "@sinequa/core/app-utils";
 import { AuditEventType, AuditWebService } from "@sinequa/core/web-services";
 import { fromEvent, merge, of, Observable, from, forkJoin, ReplaySubject, Subscription } from "rxjs";
 import { debounceTime, map, switchMap } from "rxjs/operators";
+import { IntlService } from "@sinequa/core/intl";
 
 
 @Component({
@@ -47,6 +48,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
   subscription: Subscription;
 
   constructor(
+    public intlService: IntlService,
     public suggestService: SuggestService,
     public appService: AppService,
     public previewService: PreviewService,
@@ -232,7 +234,15 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
   searchSuggestServices(text: string): Observable<ScoredAutocompleteItem<undefined,string>[]> {
     return this.suggestService.get(this.suggestQuery, text).pipe(
       map(items => items
-    .map(item => ({...item, label:"msg#autocomplete." + item.category}))
+        .map(item => { 
+                    const localeMsg = "msg#autocomplete." + item.category;
+                    if (this.intlService.formatMessage(localeMsg) === localeMsg)
+                         return item;
+                    else return ({...item, label:"msg#autocomplete." + item.category});
+                  }
+                )
+      
+//        .map(item => ({...item, label:"msg#autocomplete." + item.category}))
       )
     )
   }

--- a/projects/vanilla-search/src/app/search-form/autocomplete.component.ts
+++ b/projects/vanilla-search/src/app/search-form/autocomplete.component.ts
@@ -161,8 +161,10 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
       case "recent-query": return "fas fa-history fa-fw";
       case "basket": return "fas fa-inbox fa-fw";
       case "saved-query": return "fas fa-save fa-fw";
+      case "concept": return "far fa-lightbulb fa-fw";
+      case "textlexicon": return "fas fa-feather-alt fa-fw";
     }
-    return "far fa-lightbulb fa-fw";
+    return "fas fa-lightbulb fa-fw";
   }
 
 

--- a/projects/vanilla-search/src/app/search-form/autocomplete.component.ts
+++ b/projects/vanilla-search/src/app/search-form/autocomplete.component.ts
@@ -1,5 +1,5 @@
 import { Input, Output, Component, EventEmitter, OnInit, OnChanges, SimpleChanges, ChangeDetectionStrategy, ChangeDetectorRef, OnDestroy } from "@angular/core";
-import { AutocompleteItem, SuggestService } from "@sinequa/components/autocomplete";
+import { AutocompleteItem, SuggestService, ScoredAutocompleteItem } from "@sinequa/components/autocomplete";
 import { BasketsService } from "@sinequa/components/baskets";
 import { PreviewService } from "@sinequa/components/preview";
 import { RecentDocumentsService, RecentQueriesService, SavedQueriesService } from "@sinequa/components/saved-queries";
@@ -107,7 +107,7 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
     // Methods returning (observable of) suggestions from different sources
     const dataSources: Observable<AutocompleteItem[]>[] = this.suggestTypes.map(source => {
       switch(source) {
-        case 'suggests': return  this.suggestService.get(this.suggestQuery, value);
+        case 'suggests': return  from(this.searchSuggestServices(value));
         case 'baskets': return from(this.searchBaskets(value));
         case 'recent-documents': return from(this.searchRecentDocuments(value));
         case 'recent-queries': return from(this.searchRecentQueries(value));
@@ -222,6 +222,18 @@ export class AutocompleteComponent implements OnInit, OnChanges, OnDestroy {
       "msg#editBasket.title");
   }
 
+  /**
+   * Search for the input text with app suggest service and return autocomplete items asynchronously
+   * expects that locales/messages files contains "autocomplete.[item.category]" entry.
+   * @param text
+   */
+  searchSuggestServices(text: string): Observable<ScoredAutocompleteItem<undefined,string>[]> {
+    return this.suggestService.get(this.suggestQuery, text).pipe(
+      map(items => items
+    .map(item => ({...item, label:"msg#autocomplete." + item.category}))
+      )
+    )
+  }
 
   // Keyboard navigation and actions
 

--- a/projects/vanilla-search/src/locales/messages/de.json
+++ b/projects/vanilla-search/src/locales/messages/de.json
@@ -16,6 +16,11 @@
         "recentDocument": "Letztes Dokument"
     },
 
+    "autocomplete": {
+      "concept": "Konzept",
+      "textlexicon": "Lexikon"
+    },
+
     "facet": {
         "preview": {
             "title": "Vorschau"

--- a/projects/vanilla-search/src/locales/messages/de.json
+++ b/projects/vanilla-search/src/locales/messages/de.json
@@ -17,6 +17,10 @@
     },
 
     "autocomplete": {
+      "recentQuery": "Letzte Suche",
+      "savedQuery": "Gespeicherte Suchanfrage",
+      "recentDocument": "Letztes Dokument",
+      "basket": "Ablagekorb",
       "concept": "Konzept",
       "textlexicon": "Lexikon"
     },

--- a/projects/vanilla-search/src/locales/messages/de.json
+++ b/projects/vanilla-search/src/locales/messages/de.json
@@ -21,7 +21,7 @@
       "savedQuery": "Gespeicherte Suchanfrage",
       "recentDocument": "Letztes Dokument",
       "basket": "Ablagekorb",
-      "concept": "Konzept",
+      "concepts": "Konzept",
       "textlexicon": "Lexikon"
     },
 

--- a/projects/vanilla-search/src/locales/messages/en-gb.json
+++ b/projects/vanilla-search/src/locales/messages/en-gb.json
@@ -17,6 +17,10 @@
     },
 
     "autocomplete": {
+      "recentQuery": "Recent query",
+      "savedQuery": "Saved query",
+      "recentDocument": "Recent document",
+      "basket": "Collection",
       "concept": "Concept",
       "textlexicon": "Lexicon"
     },

--- a/projects/vanilla-search/src/locales/messages/en-gb.json
+++ b/projects/vanilla-search/src/locales/messages/en-gb.json
@@ -21,7 +21,7 @@
       "savedQuery": "Saved query",
       "recentDocument": "Recent document",
       "basket": "Collection",
-      "concept": "Concept",
+      "concepts": "Concept",
       "textlexicon": "Lexicon"
     },
 

--- a/projects/vanilla-search/src/locales/messages/en-gb.json
+++ b/projects/vanilla-search/src/locales/messages/en-gb.json
@@ -16,6 +16,11 @@
         "recentDocument": "Recent document"
     },
 
+    "autocomplete": {
+      "concept": "Concept",
+      "textlexicon": "Lexicon"
+    },
+
     "baskets": {
         "baskets": "Collections",
         "addToBasket": "Add to collection",

--- a/projects/vanilla-search/src/locales/messages/en.json
+++ b/projects/vanilla-search/src/locales/messages/en.json
@@ -17,6 +17,10 @@
     },
 
     "autocomplete": {
+      "recentQuery": "Recent query",
+      "savedQuery": "Saved query",
+      "recentDocument": "Recent document",
+      "basket": "Collection",
       "concept": "Concept",
       "textlexicon": "Lexicon"
     },

--- a/projects/vanilla-search/src/locales/messages/en.json
+++ b/projects/vanilla-search/src/locales/messages/en.json
@@ -21,7 +21,7 @@
       "savedQuery": "Saved query",
       "recentDocument": "Recent document",
       "basket": "Collection",
-      "concept": "Concept",
+      "concepts": "Concept",
       "textlexicon": "Lexicon"
     },
 

--- a/projects/vanilla-search/src/locales/messages/en.json
+++ b/projects/vanilla-search/src/locales/messages/en.json
@@ -16,6 +16,11 @@
         "recentDocument": "Recent document"
     },
 
+    "autocomplete": {
+      "concept": "Concept",
+      "textlexicon": "Lexicon"
+    },
+
     "baskets": {
         "baskets": "Collections",
         "addToBasket": "Add to collection",

--- a/projects/vanilla-search/src/locales/messages/fr.json
+++ b/projects/vanilla-search/src/locales/messages/fr.json
@@ -17,6 +17,10 @@
     },
 
     "autocomplete": {
+      "recentQuery": "Recherche récente",
+      "savedQuery": "Requête sauvegardée",
+      "recentDocument": "Document récent",
+      "basket": "Collection",
       "concept": "Concept",
       "textlexicon": "Lexique"
     },

--- a/projects/vanilla-search/src/locales/messages/fr.json
+++ b/projects/vanilla-search/src/locales/messages/fr.json
@@ -17,11 +17,11 @@
     },
 
     "autocomplete": {
-      "recentQuery": "Recherche récente",
+      "recentQuery": "Requête récente",
       "savedQuery": "Requête sauvegardée",
       "recentDocument": "Document récent",
       "basket": "Collection",
-      "concept": "Concept",
+      "concepts": "Concept",
       "textlexicon": "Lexique"
     },
 

--- a/projects/vanilla-search/src/locales/messages/fr.json
+++ b/projects/vanilla-search/src/locales/messages/fr.json
@@ -16,6 +16,11 @@
         "recentDocument": "Document récent"
     },
 
+    "autocomplete": {
+      "concept": "Concept",
+      "textlexicon": "Lexique"
+    },
+
     "baskets": {
         "baskets": "Collections",
         "addToBasket": "Ajouter à la collection",


### PR DESCRIPTION
with the "recherche" vs "requête" labels in French and the concepts and textlexicon categories without translation, we could do something
![suggestion_en](https://github.com/sinequa/sba-angular/assets/154341492/d949e3db-7919-4c40-afc1-acfe4f5cfc03)
![suggestion_fr](https://github.com/sinequa/sba-angular/assets/154341492/6d74376a-b614-4584-8515-c745f9dda8c0)
![new_suggestion_en](https://github.com/sinequa/sba-angular/assets/154341492/395c704a-20cc-4e59-8e1e-4bedd71ce515)
![new_suggestion_fr](https://github.com/sinequa/sba-angular/assets/154341492/0c1ba093-3c91-46d5-9394-96e3f5d8ba3b)
